### PR TITLE
job:#8238 I modified GD_ARS.createConnectorsNoGraphics to handle

### DIFF
--- a/src/org.xtuml.bp.ui.canvas/models/org.xtuml.bp.ui.canvas/ooaofgraphics/External Entities/External Entities.xtuml
+++ b/src/org.xtuml.bp.ui.canvas/models/org.xtuml.bp.ui.canvas/ooaofgraphics/External Entities/External Entities.xtuml
@@ -1671,6 +1671,25 @@ INSERT INTO S_BPARM
 	'',
 	"00000000-0000-0000-0000-000000000000",
 	'');
+INSERT INTO S_BRG
+	VALUES ("cd82f423-3cc5-46a2-baee-6a2fcbebcf88",
+	"f168c92b-6d64-4ecb-a677-5a1d7cce8352",
+	'isReflexive',
+	'',
+	0,
+	"ba5eda7a-def5-0000-0000-000000000001",
+	'',
+	0,
+	'');
+INSERT INTO S_BPARM
+	VALUES ("bffa429a-d271-478c-b69e-586a2d4cdecf",
+	"cd82f423-3cc5-46a2-baee-6a2fcbebcf88",
+	'nrme',
+	"68dedb08-fd5a-420e-9ec7-e7985ad0c856",
+	0,
+	'',
+	"00000000-0000-0000-0000-000000000000",
+	'');
 INSERT INTO PE_PE
 	VALUES ("f168c92b-6d64-4ecb-a677-5a1d7cce8352",
 	1,

--- a/src/org.xtuml.bp.ui.canvas/models/org.xtuml.bp.ui.canvas/ooaofgraphics/Graphical Data/Auto Reconciliation Specification/Auto Reconciliation Specification.xtuml
+++ b/src/org.xtuml.bp.ui.canvas/models/org.xtuml.bp.ui.canvas/ooaofgraphics/Graphical Data/Auto Reconciliation Specification/Auto Reconciliation Specification.xtuml
@@ -341,6 +341,7 @@ end if;
 // the "other side" of a connector. This return value is 
 // only used by the recursive call.
 searchingForSide2=false;
+side2SearchLookingForReflexive=false;
 if (param.connector_ooa_id_to_find != OS::NULL_UNIQUE_ID())
   searchingForSide2=true;
 end if;
@@ -408,14 +409,34 @@ while (j < connectorCount)
     end if;
   end for;
 
+  // get association instance and name
+  connectorInstance = CL::getOOAInstance(from:connectorOOAId, rootInst:model.represents);
+  connectorName = CL::getModelElementName(from:connectorInstance);
+
+  // This is used only by the reflexive call, and
+  // the reflive call ends with this block.
   if (searchingForSide2)
+    side2GDGEId=OS::NULL_UNIQUE_ID();
     if ((connectorOOAId == param.connector_ooa_id_to_find))
       if (graphicalElement.represents != param.shape_ooa_instance_to_find)
-        // We found the other side! Return the shape ID
-        return graphicalElement.elementId;      
+        // We found the other side! 
+        side2GDGEId = graphicalElement.elementId;      
       else
-        // TODO: FIXME: We are not yet dealong with reflexives
+        //check for reflexive
+        if (side2SearchLookingForReflexive)
+          side2GDGEId = param.element_id;
+        end if;
+        // Special case for reflexive, unformalized R_SIMP
+        // and event to self
+        isReflexive = CL::isReflexive(nrme:connectorInstance);
+        if (isReflexive) 
+          side2GDGEId = param.element_id;      
+        end if;         
       end if;
+      if (side2GDGEId != OS::NULL_UNIQUE_ID())
+        return side2GDGEId;
+      end if;
+      side2SearchLookingForReflexive = true;            
     end if;    
     j = j + 1;
     continue;
@@ -475,9 +496,6 @@ while (j < connectorCount)
 	  if (not empty side2_GD_GE) 
 	    side2_ElementName = CL::getModelElementName(from:side2_GD_GE.represents);
 	  end if;
-	  // get association name
-	  connectorInstance = CL::getOOAInstance(from:connectorOOAId, rootInst:model.represents);
-	  connectorName = CL::getModelElementName(from:connectorInstance);
 	  
 	  msg = CL::getModelElementName(from:graphicalElement.represents) + 
 	        " participates in " +

--- a/src/org.xtuml.bp.ui.canvas/src/org/xtuml/bp/ui/canvas/Cl_c.java
+++ b/src/org.xtuml.bp.ui.canvas/src/org/xtuml/bp/ui/canvas/Cl_c.java
@@ -44,6 +44,7 @@ import org.xtuml.bp.core.Association_c;
 import org.xtuml.bp.core.AsynchronousMessage_c;
 import org.xtuml.bp.core.BinaryAssociation_c;
 import org.xtuml.bp.core.ClassAsLink_c;
+import org.xtuml.bp.core.ClassAsSimpleParticipant_c;
 import org.xtuml.bp.core.ClassAsSubtype_c;
 import org.xtuml.bp.core.ClassInEngine_c;
 import org.xtuml.bp.core.ClassInState_c;
@@ -79,6 +80,7 @@ import org.xtuml.bp.core.Lifespan_c;
 import org.xtuml.bp.core.LinkedAssociation_c;
 import org.xtuml.bp.core.ModelClass_c;
 import org.xtuml.bp.core.Monitor_c;
+import org.xtuml.bp.core.NoEventTransition_c;
 import org.xtuml.bp.core.ObjectNode_c;
 import org.xtuml.bp.core.Ooaofooa;
 import org.xtuml.bp.core.PackageParticipant_c;
@@ -87,6 +89,7 @@ import org.xtuml.bp.core.Provision_c;
 import org.xtuml.bp.core.Requirement_c;
 import org.xtuml.bp.core.ReturnMessage_c;
 import org.xtuml.bp.core.SendSignal_c;
+import org.xtuml.bp.core.SimpleAssociation_c;
 import org.xtuml.bp.core.StateMachineState_c;
 import org.xtuml.bp.core.StateMachine_c;
 import org.xtuml.bp.core.StructuredDataType_c;
@@ -2029,4 +2032,30 @@ public static void Settoolbarstate(boolean readonly) {
     public static String Getmodelelementname(final Object From) {
     	return s_invoke(From, "getName", null, null);
     }
+    
+    // This is really sort-of a hack around the ooag -> ooaofooa 
+    // interface for graphics reconciliation which is
+    // defined by GD_ARS. This is a special case for 
+    // reflexives
+    public static Boolean Isreflexive(final Object connectorInstance) {
+    	boolean isReflexive = false;
+    	if (connectorInstance instanceof Association_c) {
+    		Association_c assoc = (Association_c)connectorInstance;
+			ClassAsSimpleParticipant_c[] parts = ClassAsSimpleParticipant_c
+					.getManyR_PARTsOnR207(SimpleAssociation_c.getOneR_SIMPOnR206(assoc));
+    		if (parts.length > 1) {
+    			isReflexive = true;
+    		}
+    	} else if (connectorInstance instanceof Transition_c) {
+			Transition_c trans = (Transition_c) connectorInstance;
+			StateMachineState_c smsDest = StateMachineState_c.getOneSM_STATEOnR506(trans);
+			StateMachineState_c smsSource = StateMachineState_c
+					.getOneSM_STATEOnR508(NoEventTransition_c.getOneSM_NETXNOnR507(trans));
+    		if (smsDest == smsSource) {
+    			isReflexive = true;
+    		}
+    	}
+    	return isReflexive;
+    }
+    
 }// End Cl_c


### PR DESCRIPTION
reflexives in its recursive call to find the connector's "side2" shape.
This is working for simple cases. When there are multiple reflexives (or
events to self the connector point are not being created uniquely, and
thus, multiple reflexives can be selected independently, but their
connector points are shared. I will fix this next.