### PR TITLE
job:#8238 I explicitly removed reconciliation of linked associations

### DIFF
--- a/src/org.xtuml.bp.ui.canvas/models/org.xtuml.bp.ui.canvas/ooaofgraphics/Graphical Data/Auto Reconciliation Specification/Auto Reconciliation Specification.xtuml
+++ b/src/org.xtuml.bp.ui.canvas/models/org.xtuml.bp.ui.canvas/ooaofgraphics/Graphical Data/Auto Reconciliation Specification/Auto Reconciliation Specification.xtuml
@@ -327,7 +327,7 @@ select one targetSpec related by self->GD_ES[R31];
 select any model related by self->GD_ES[R31]->GD_EMS[R11]->GD_MS[R11]->GD_MD[R9] where (selected.diagramId==param.diagram_id);
 select any graphicalElement related by model->GD_GE[R1] where (selected.elementId==param.element_id);
 
-// TODO: FIXME: Interface connectors are note being reconciled yet. 
+// TODO: FIXME: Interface connectors are not being reconciled yet. 
 //   This causes us to just ignore them for now.
 if ((targetSpec.Name=="Imported Provided Interface") or
 	(targetSpec.Name=="Imported Required Interface") or
@@ -335,6 +335,11 @@ if ((targetSpec.Name=="Imported Provided Interface") or
 	(targetSpec.Name=="Required Interface")
    )
    return OS::NULL_UNIQUE_ID();
+end if;
+//TODO: FIXME: Linked assoc are not being reconcilced yet
+if ((self.Bridge_NumElements=="Getassociativelinkonecount") or
+    (self.Bridge_NumElements=="Getassociativelinkothercount"))
+    return OS::NULL_UNIQUE_ID();
 end if;
 
 // This operation calls itself recursively to find

--- a/src/org.xtuml.bp.ui.canvas/src/org/xtuml/bp/ui/canvas/Cl_c.java
+++ b/src/org.xtuml.bp.ui.canvas/src/org/xtuml/bp/ui/canvas/Cl_c.java
@@ -44,6 +44,7 @@ import org.xtuml.bp.core.Association_c;
 import org.xtuml.bp.core.AsynchronousMessage_c;
 import org.xtuml.bp.core.BinaryAssociation_c;
 import org.xtuml.bp.core.ClassAsLink_c;
+import org.xtuml.bp.core.ClassAsSimpleFormalizer_c;
 import org.xtuml.bp.core.ClassAsSimpleParticipant_c;
 import org.xtuml.bp.core.ClassAsSubtype_c;
 import org.xtuml.bp.core.ClassInEngine_c;
@@ -80,6 +81,7 @@ import org.xtuml.bp.core.Lifespan_c;
 import org.xtuml.bp.core.LinkedAssociation_c;
 import org.xtuml.bp.core.ModelClass_c;
 import org.xtuml.bp.core.Monitor_c;
+import org.xtuml.bp.core.NewStateTransition_c;
 import org.xtuml.bp.core.NoEventTransition_c;
 import org.xtuml.bp.core.ObjectNode_c;
 import org.xtuml.bp.core.Ooaofooa;
@@ -90,6 +92,7 @@ import org.xtuml.bp.core.Requirement_c;
 import org.xtuml.bp.core.ReturnMessage_c;
 import org.xtuml.bp.core.SendSignal_c;
 import org.xtuml.bp.core.SimpleAssociation_c;
+import org.xtuml.bp.core.StateEventMatrixEntry_c;
 import org.xtuml.bp.core.StateMachineState_c;
 import org.xtuml.bp.core.StateMachine_c;
 import org.xtuml.bp.core.StructuredDataType_c;
@@ -2043,15 +2046,30 @@ public static void Settoolbarstate(boolean readonly) {
     		Association_c assoc = (Association_c)connectorInstance;
 			ClassAsSimpleParticipant_c[] parts = ClassAsSimpleParticipant_c
 					.getManyR_PARTsOnR207(SimpleAssociation_c.getOneR_SIMPOnR206(assoc));
-    		if (parts.length > 1) {
-    			isReflexive = true;
+			if (parts.length == 1) {
+				// check for formalized reflexive
+				ClassAsSimpleFormalizer_c form = ClassAsSimpleFormalizer_c
+						.getOneR_FORMOnR208(SimpleAssociation_c.getOneR_SIMPOnR206(assoc));
+				if (parts[0].getObj_id() ==form.getObj_id()) {
+					isReflexive = true;
+	  			}
+			} else if (parts.length > 1) {
+    			// check for unformalized reflexive
+    			if (parts[0].getObj_id() == parts[1].getObj_id()) {
+      			  isReflexive = true;
+    			}
     		}
     	} else if (connectorInstance instanceof Transition_c) {
 			Transition_c trans = (Transition_c) connectorInstance;
 			StateMachineState_c smsDest = StateMachineState_c.getOneSM_STATEOnR506(trans);
-			StateMachineState_c smsSource = StateMachineState_c
+			
+			StateMachineState_c smsSourceNoEventTrans = StateMachineState_c
 					.getOneSM_STATEOnR508(NoEventTransition_c.getOneSM_NETXNOnR507(trans));
-    		if (smsDest == smsSource) {
+			
+			StateMachineState_c smsSourceNewStateTrans = StateMachineState_c.getOneSM_STATEOnR503(
+					StateEventMatrixEntry_c.getOneSM_SEMEOnR504(NewStateTransition_c.getOneSM_NSTXNOnR507(trans)));
+					
+    		if ((smsDest != null) && (smsDest == smsSourceNoEventTrans || smsDest == smsSourceNewStateTrans)) {
     			isReflexive = true;
     		}
     	}


### PR DESCRIPTION
until they are properly in place. I also fixed some problems with
reflexives found while testing. The problems were in the logic in the
CL_c.java::.isReflexive() operation I created that returns true when a
given connector type is a reflexive. Some logic there was bad, and it
was incomplete.