### PR TITLE
job:#8238 Found and fixed the remaining problem with Linked Associations

### DIFF
--- a/src/org.xtuml.bp.ui.canvas/models/org.xtuml.bp.ui.canvas/ooaofgraphics/Graphical Data/Auto Reconciliation Specification/Auto Reconciliation Specification.xtuml
+++ b/src/org.xtuml.bp.ui.canvas/models/org.xtuml.bp.ui.canvas/ooaofgraphics/Graphical Data/Auto Reconciliation Specification/Auto Reconciliation Specification.xtuml
@@ -472,6 +472,10 @@ while (j < connectorCount)
             select one connectorSpec related  by shapeARSInstance->GD_ES[R31];
             if  (connectorSpec.symbolType=="connector")
               if (not empty connectorSpec)
+                // The Class As Link is only handled during the last pass after the other connectors have been created
+                if (param.passNumber!=3 and shapeARSInstance.Bridge_NumElements=="Getclassaslinkcount")
+                  continue;
+                end if;
                 side2_GD_GEId = shapeARSInstance.reconcileConnectorsNoExistingGraphics(diagram_id:model.diagramId, 
             						 system_id:param.system_id, element_id:shapeInPackage.elementId,
             						 		connector_ooa_id_to_find:connectorOOAId,


### PR DESCRIPTION
the problem was that in GD_ARS.reconcilConnectorsNoExitingGraphics() we
must prevent the recursive search to find the other side with type
GD_ARS.Bridge_NumElements="Getclassaslinkcount" until pass 3 when we are
creating the R_ASSR->R_ASSOC portion of the linked association (after
The R_AONE->R_AOTH has been created.